### PR TITLE
Changed bucket destination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ after_script:
 before_deploy: "npm run package"
 deploy:
   provider: s3
-  bucket: fedramp-dashboard-demo
+  bucket: marketplace.fedramp.gov
   region: us-east-1
   skip_cleanup: true
   local_dir: "build/dest"


### PR DESCRIPTION
Pursuant to http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingCustomURLs, the bucket should match the CNAME for the
subdomain. In other words, fedramp-dashboard-demo must now become
marketplace.fedramp.gov.
