### PR TITLE
Update Navigation to change Newsroom to Blog

### DIFF
--- a/src/templates/components/navigation.html
+++ b/src/templates/components/navigation.html
@@ -105,10 +105,9 @@
             </ul>
         </li>
         <li class="dropdown">
-            <a href="#" title="Blog">Blog</a>
+            <a href="#" title="FedRAMP Blog">FedRAMP Blog</a>
             <ul class="dropdown-content down">
-                <li><a href="https://www.fedramp.gov/fedramp-blog/" title="Blog">Blog</a></li>
-                <li><a href="https://www.fedramp.gov/events/" title="Events">Events</a></li>
+                <li><a href="https://www.fedramp.gov/fedramp-blog/" title="FedRAMP Blog">FedRAMP Blog</a></li>
             </ul>
         </li>
     </ul>

--- a/src/templates/components/navigation.html
+++ b/src/templates/components/navigation.html
@@ -105,9 +105,9 @@
             </ul>
         </li>
         <li class="dropdown">
-            <a href="#" title="Newsroom">Newsroom</a>
+            <a href="#" title="Blog">Blog</a>
             <ul class="dropdown-content down">
-                <li><a href="https://www.fedramp.gov/category/newsroom/" title="Newsroom">Newsroom</a></li>
+                <li><a href="https://www.fedramp.gov/fedramp-blog/" title="Blog">Blog</a></li>
                 <li><a href="https://www.fedramp.gov/events/" title="Events">Events</a></li>
             </ul>
         </li>

--- a/src/templates/components/navigation.html
+++ b/src/templates/components/navigation.html
@@ -105,9 +105,9 @@
             </ul>
         </li>
         <li class="dropdown">
-            <a href="#" title="FedRAMP Blog">FedRAMP Blog</a>
+            <a href="#" title="Blog">Blog</a>
             <ul class="dropdown-content down">
-                <li><a href="https://www.fedramp.gov/fedramp-blog/" title="FedRAMP Blog">FedRAMP Blog</a></li>
+                <li><a href="https://www.fedramp.gov/fedramp-blog/" title="Blog">Blog</a></li>
             </ul>
         </li>
     </ul>


### PR DESCRIPTION
Changed Label of Newsroom to blog, added updated link to: https://www.fedramp.gov/fedramp-blog/
