### PR TITLE
Fix mixed content warning

### DIFF
--- a/src/templates/components/search.html
+++ b/src/templates/components/search.html
@@ -1,6 +1,6 @@
 <div class="usa-grid limit">
     <div class="usa-width-one-whole">
-        <form id="search_form" class="usa-search" method="get" ng-submit="controller.search($event)" accept-charset="UTF-8" action="http://search.usa.gov/search">
+        <form id="search_form" class="usa-search" method="get" ng-submit="controller.search($event)" accept-charset="UTF-8" action="https://search.usa.gov/search">
             <input type="hidden" name="utf8" value="✓" />
             <input type="hidden" name="affiliate" id="affiliate" value="fedramp" />
             <input type="hidden" name="format" id="format" value="{{controller.format}}" />


### PR DESCRIPTION
marketplace.fedramp.gov currently doesn't get a green lock in Chrome, because it has a mixed content warning for pointing the search form at an insecure URI. This adds an `s` to the URL to point the form at a secure URL.
