### PR TITLE
display agencies using dependent products

### DIFF
--- a/src/fedramp.services/storage-data.factory.js
+++ b/src/fedramp.services/storage-data.factory.js
@@ -188,32 +188,46 @@
                     items.push(item);
                 }
 
+                // Don't repeat yourself.
+                let addAgencies = (d, item) => {
+                    if (validAgency(d.sponsoringAgency) && include(d.sponsoringAgency, item.agencies)) {
+                        item.agencies.push(d.sponsoringAgency.trim());
+                    }
+
+                    if (validAgency(d.authorizingAgency) && include(d.authorizingAgency, item.agencies)) {
+                        item.agencies.push(d.authorizingAgency.trim());
+                    }
+
+                    if (validAgency(d.authorizingSubagency) && include(d.authorizingSubagency, item.agencies)) {
+                        item.agencies.push(d.authorizingSubagency.trim());
+                    }
+
+                    d.atoLetters.forEach(a => {
+                        if (validAgency(a.authorizingAgency) && include(a.authorizingAgency, item.agencies)) {
+                            item.agencies.push(a.authorizingAgency.trim());
+                        }
+
+                        if (validAgency(a.authorizingSubagency) && include(a.authorizingSubagency, item.agencies)) {
+                            item.agencies.push(a.authorizingSubagency.trim());
+                        }
+                    });
+                };
+
                 items.forEach(item => {
                     data.forEach(d => {
                         if (d.pkg.trim() === item.name) {
-                            if (validAgency(d.sponsoringAgency) && include(d.sponsoringAgency, item.agencies)) {
-                                item.agencies.push(d.sponsoringAgency.trim());
-                            }
-
-                            if (validAgency(d.authorizingAgency) && include(d.authorizingAgency, item.agencies)) {
-                                item.agencies.push(d.authorizingAgency.trim());
-                            }
-
-                            if (validAgency(d.authorizingSubagency) && include(d.authorizingSubagency, item.agencies)) {
-                                item.agencies.push(d.authorizingSubagency.trim());
-                            }
-
-                            d.atoLetters.forEach(a => {
-                                if (validAgency(a.authorizingAgency) && include(a.authorizingAgency, item.agencies)) {
-                                    item.agencies.push(a.authorizingAgency.trim());
-                                }
-
-                                if (validAgency(a.authorizingSubagency) && include(a.authorizingSubagency, item.agencies)) {
-                                    item.agencies.push(a.authorizingSubagency.trim());
-                                }
-                            });
+                            addAgencies(d, item);
                         }
                     });
+
+                    // Add agencies that use dependent products.
+                    if(item.hasOwnProperty('dependents')) {
+                        item.dependents.forEach(name => {
+                            let d = data.find(item => { return item.pkg.trim() === name; });
+
+                            addAgencies(d, item);
+                        });
+                    }
                 });
 
                 return items;

--- a/src/fedramp.services/storage-data.factory.js
+++ b/src/fedramp.services/storage-data.factory.js
@@ -188,7 +188,6 @@
                     items.push(item);
                 }
 
-                // Don't repeat yourself.
                 let addAgencies = (d, item) => {
                     if (validAgency(d.sponsoringAgency) && include(d.sponsoringAgency, item.agencies)) {
                         item.agencies.push(d.sponsoringAgency.trim());
@@ -394,41 +393,10 @@
                     }
                 }
 
-                items.forEach(item => {
-                    data.forEach(d => {
-                        d.atoLetters
-                            .filter(x => safeTrim(x.authorizingAgency) === item.name || safeTrim(x.authorizingSubagency) === item.name)
-                            .forEach(a => {
-                                item.authorized++;
-                                if (include(d.pkg, item.products)) {
-                                    item.products.push(d.pkg.trim());
-                                }
-
-                                if (include(d.name, item.providers)) {
-                                    item.providers.push(d.name.trim());
-                                }
-
-                                if (include(a.independentAssessor, item.assessors)) {
-                                    item.assessors.push(a.independentAssessor.trim());
-                                }
-                            });
-
-                        if (safeTrim(d.sponsoringAgency) === item.name) {
-                            item.sponsored++;
-                            if (include(d.pkg, item.products)) {
-                                item.products.push(d.pkg.trim());
-                            }
-
-                            if (include(d.name, item.providers)) {
-                                item.providers.push(d.name.trim());
-                            }
-
-                            if (include(d.independentAssessor, item.assessors)) {
-                                item.assessors.push(d.independentAssessor.trim());
-                            }
-                        }
-
-                        if (safeTrim(d.authorizingAgency) === item.name || safeTrim(d.authorizingSubagency) === item.name) {
+                let addProducts = (d, item) => {
+                    d.atoLetters
+                        .filter(x => safeTrim(x.authorizingAgency) === item.name || safeTrim(x.authorizingSubagency) === item.name)
+                        .forEach(a => {
                             item.authorized++;
                             if (include(d.pkg, item.products)) {
                                 item.products.push(d.pkg.trim());
@@ -438,9 +406,68 @@
                                 item.providers.push(d.name.trim());
                             }
 
-                            if (include(d.independentAssessor, item.assessors)) {
-                                item.assessors.push(d.independentAssessor.trim());
+                            if (include(a.independentAssessor, item.assessors)) {
+                                item.assessors.push(a.independentAssessor.trim());
                             }
+                        });
+
+                    if (safeTrim(d.sponsoringAgency) === item.name) {
+                        item.sponsored++;
+                        if (include(d.pkg, item.products)) {
+                            item.products.push(d.pkg.trim());
+                        }
+
+                        if (include(d.name, item.providers)) {
+                            item.providers.push(d.name.trim());
+                        }
+
+                        if (include(d.independentAssessor, item.assessors)) {
+                            item.assessors.push(d.independentAssessor.trim());
+                        }
+                    }
+
+                    if (safeTrim(d.authorizingAgency) === item.name || safeTrim(d.authorizingSubagency) === item.name) {
+                        item.authorized++;
+                        if (include(d.pkg, item.products)) {
+                            item.products.push(d.pkg.trim());
+                        }
+
+                        if (include(d.name, item.providers)) {
+                            item.providers.push(d.name.trim());
+                        }
+
+                        if (include(d.independentAssessor, item.assessors)) {
+                            item.assessors.push(d.independentAssessor.trim());
+                        }
+                    }
+                };
+
+                items.forEach(item => {
+                    // Add all primary products.
+                    data.forEach(d => {
+                        addProducts(d, item);
+                    });
+
+                    // For each primary product, add its underlying products to the list.
+                    item.products.forEach(name => {
+                        let product = data.find(item => { return item.pkg.trim() === name; });
+
+                        if (product.hasOwnProperty('underlyingCspPackages')) {
+                            product.underlyingCspPackages.forEach(function (pkgId) {
+                                let underlying = data.find(item => { return item.pkgId.trim() === pkgId; });
+
+                                if (include(underlying.pkg, item.products)) {
+                                    item.products.push(underlying.pkg.trim());
+                                }
+
+                                if (include(underlying.name, item.providers)) {
+                                    item.providers.push(underlying.name.trim());
+                                }
+
+                                if (include(underlying.independentAssessor, item.assessors)) {
+                                    item.assessors.push(underlying.independentAssessor.trim());
+                                }
+                            });
                         }
                     });
 

--- a/test/fedramp.services/storage-data.factory.test.js
+++ b/test/fedramp.services/storage-data.factory.test.js
@@ -175,6 +175,26 @@ describe('StorageData manager', function () {
         expect(storage.products().length).toBe(1);
     });
 
+    it('can return products with dependents', function () {
+        var data = TestData.Dependents.map(function(data) {
+            return new Data(data);
+        });
+        var storage = new StorageData();
+        storage.clear();
+        data.forEach(function(item) {
+            storage.update(item.hash(), item);
+        });
+
+        var pkgId = 'F1510137547'; // i.e., Datapipe
+        var agency = 'National Science Foundation';
+
+        var product = storage.products().find(function(item) {
+            return item.pkgId === pkgId;
+        });
+
+        expect(product.agencies.indexOf(agency) !== -1).toBe(true);
+    });
+
     it('can return agencies', function () {
         var data = new Data(TestData.Letters[0]);
         var storage = new StorageData();

--- a/test/fedramp.services/storage-data.factory.test.js
+++ b/test/fedramp.services/storage-data.factory.test.js
@@ -203,6 +203,23 @@ describe('StorageData manager', function () {
         expect(storage.agencies().length).toBe(2);
     });
 
+    it('can return agencies with dependents', function () {
+        var data = TestData.Dependents.map(function(data) {
+            return new Data(data);
+        });
+        var storage = new StorageData();
+        storage.clear();
+        data.forEach(function(item) {
+            storage.update(item.hash(), item);
+        });
+
+        var agency = storage.agencies().find(function(item) {
+            return item.name === 'National Science Foundation';
+        });
+
+        expect(agency.products.length).toBe(2); // i.e., it should include Datapipe in addition to Accenture
+    });
+
     it('can return assessors', function () {
         var data = new Data(TestData.Letters[0]);
         var storage = new StorageData({Assessors: TestData.AssessorData});

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -1,4 +1,75 @@
 var TestData = {
+    Dependents: [
+        {
+            "Cloud_Service_Provider_Name": "Accenture",
+            "Cloud_Service_Provider_Package": "Accenture Federal Cloud ERP",
+            "Path": "Agency",
+            "Designation": "Compliant",
+            "Package_ID": "F1404043549",
+            "Service_Model": [
+                "SaaS"
+            ],
+            "Deployment_Model": "Government Community Cloud",
+            "Impact_Level": "Moderate",
+            "Original_Authorization_Date": "2016-06-20T04:00:00.000Z",
+            "Original_Expiration_Date": "2019-06-20T04:00:00.000Z",
+            "Sponsoring_Agency": "National Science Foundation",
+            "Sponsoring_Agency_Logo": "https://www.fedramp.gov/files/2016/08/Accenture-Logo-1.jpg",
+            "Authorizing_Agency": "National Science Foundation",
+            "CSP_URL": "https://www.fedramp.gov/files/2016/03/image001-300x215.png",
+            "Independent_Assessor": "Veris Group, LLC",
+            "Underlying_CSP_Package_ID": [
+                "F1510137547"
+            ],
+            "FedRAMP_Website_URL": "https://www.fedramp.gov/marketplace/compliant-systems/accenture-accenture-federal-cloud-erp/",
+            "CSP_Website": "https://www.accenture.com/us-en/afs-industry-index.aspx",
+            "CSO_Description": "Federal Cloud ERP is a secure cloud offering delivering virtualized back office ERP solutions to US federal customers.  Accenture leverages industry leading software, virtualized technology and assets created from more than 20 years of implementations to help our federal customers to meet their unique mission requirements.",
+            "Announcement_Date": "2016-06-24T04:00:00.000Z",
+            "CSP_POC_Name": "Faisal Mian",
+            "CSP_POC_Email": "FedRAMP@accenturefederal.com",
+            "FedRAMP_In-Process_Date": "2016-03-21T04:00:00.000Z",
+            "Agency_POC": "Coming Soon",
+            "Leveraged_ATO_Letters": []
+        },
+        {
+            "Cloud_Service_Provider_Name": "Datapipe Government Solutions",
+            "Cloud_Service_Provider_Package": "Datapipe Government Solutions Federal Community Cloud Platform",
+            "Path": "JAB",
+            "Designation": "Compliant",
+            "Package_ID": "F1510137547",
+            "Service_Model": [
+                "PaaS"
+            ],
+            "Deployment_Model": "Government Community Cloud",
+            "Impact_Level": "Moderate",
+            "Original_Authorization_Date": "2015-10-09T04:00:00.000Z",
+            "Sponsoring_Agency": "JAB Authorization",
+            "Sponsoring_Agency_Logo": "https://www.fedramp.gov/files/2015/06/FedRAMP_logo_no_text-e1434026500879.png",
+            "Authorizing_Agency": "JAB Authorization",
+            "CSP_URL": "https://www.fedramp.gov/files/2015/02/B3F5AA50-4500-416B-932B-CE94C8A4605725-e1443618854518.png",
+            "Independent_Assessor": "Coalfire Systems, Inc.",
+            "FedRAMP_Website_URL": "https://www.fedramp.gov/marketplace/compliant-systems/datapipe-government-solutions-federal-community-cloud-platform/",
+            "CSP_Website": "www.datapipe.com/government",
+            "Announcement_Date": "2015-10-09T04:00:00.000Z",
+            "CSP_POC_Name": "Dan Tudahl",
+            "CSP_POC_Email": "fedrampinfo@datapipe.com",
+            "FedRAMP_In-Process_Date": "2014-02-04T05:00:00.000Z",
+            "Agency_POC": "Coming Soon",
+            "Leveraged_ATO_Letters": [
+                {
+                    "Letter_Date": "2016-09-01T04:00:00.000Z",
+                    "Authorizing_Agency": "Department of Justice",
+                    "Authorizing_Subagency": "Office of Justice Programs",
+                    "Agency_POC": "Coming Soon",
+                    "Agency_Logo": "https://www.fedramp.gov/files/2016/08/Seal_of_the_United_States_Department_of_Justice.png",
+                    "Include_In_Marketplace": "Y",
+                    "Independent_Assessor": "Coalfire Systems, Inc.",
+                    "Announcement_Date": "2016-09-01T04:00:00.000Z"
+                }
+            ]
+        }
+    ],
+
     Letters: [
         {
             'Cloud_Service_Provider_Name': 'Akamai',
@@ -33,7 +104,7 @@ var TestData = {
                     'Independent_Assessor': 'ACME'
                 }
             ]
-        }], 
+        }],
 
     GithubContent: [
         {


### PR DESCRIPTION
I modified `StorageData.products()` to find the `Data` object corresponding to each dependent product and add its agencies to the list.

My associated test ensures that `/product/datapipe-government-solutions-federal-community-cloud-platform` lists the National Science Foundation, as desired.
