### PR TITLE
hardcode to use both fr.cloud.gov and app.cloud.gov

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,9 @@ applications:
   memory: 64M
   instances: 2
   path: "dist"
+  domains:
+  - app.cloud.gov
+  - fr.cloud.gov
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
   env:
     FORCE_HTTPS: true


### PR DESCRIPTION
Until we can get a clear path to update the DNS distribution on fedramp's side, they need  to keep the fr.cloud.gov domain.