### PR TITLE
Include product description in app search

### DIFF
--- a/src/fedramp.components/products-grid.component.js
+++ b/src/fedramp.components/products-grid.component.js
@@ -139,7 +139,7 @@
             searchTerm = searchTerm.toLowerCase();
             var productName = product.name.toLowerCase();
             var providerName = product.provider.toLowerCase();
-            var providerDescription = product.csoDescription.toLowerCase();
+            var providerDescription = product.serviceDescription.toLowerCase();
 
             if (productName.indexOf(searchTerm) !== -1 ||
                 providerName.indexOf(searchTerm) !== -1 ||

--- a/src/fedramp.components/products-grid.component.js
+++ b/src/fedramp.components/products-grid.component.js
@@ -135,12 +135,15 @@
             if (!searchTerm) {
                 return product;
             }
-
+            console.log('product', product);
             searchTerm = searchTerm.toLowerCase();
             var productName = product.name.toLowerCase();
             var providerName = product.provider.toLowerCase();
+            var providerDescription = product.csoDescription.toLowerCase();
 
-            if (productName.indexOf(searchTerm) !== -1 || providerName.indexOf(searchTerm) !== -1) {
+            if (productName.indexOf(searchTerm) !== -1 ||
+                providerName.indexOf(searchTerm) !== -1 ||
+                providerDescription.indexOf(searchTerm) !== -1) {
                 return product;
             }
 

--- a/test/fedramp.components/products-grid.component.test.js
+++ b/test/fedramp.components/products-grid.component.test.js
@@ -100,11 +100,11 @@ describe('The product-grid component', function () {
         var product = new Product();
         product.name = 'App Engine';
         product.provider = 'Google';
-        product.csoDescription = 'Foo';
+        product.serviceDescription = 'Foo';
 
         var filtered = component.productNameSearchFilterFunc(product, 0, [product], 'Foo');
         expect(filtered).toBeDefined();
-        expect(filtered.csoDescription).toBe('Foo');
+        expect(filtered.serviceDescription).toBe('Foo');
     }));
 
     it('it can filter by status', inject(function (Product) {

--- a/test/fedramp.components/products-grid.component.test.js
+++ b/test/fedramp.components/products-grid.component.test.js
@@ -17,13 +17,13 @@ describe('The product-grid component', function () {
                 $attrs: {
                     hideFilters: false
                 }
-            }, 
+            },
             {
                 rawItems: [
                     {
                         'name': 'App Engine'
                     },
-                    
+
                     {
                         'name': 'Microsoft'
                     }
@@ -44,7 +44,7 @@ describe('The product-grid component', function () {
     it('it executes callback function', function () {
         var onUpdate = function(){
         };
-        var items = [            
+        var items = [
             {
                 'name': 'App Engine'
             },
@@ -56,7 +56,7 @@ describe('The product-grid component', function () {
 
         var grid = testDataFactory.productsGridComponent({
             onUpdate: onUpdate,
-            rawItems: items 
+            rawItems: items
         },{
             $attrs: {
                 hideFilters: false
@@ -76,7 +76,7 @@ describe('The product-grid component', function () {
 
     it('it can filter be reuse range', inject(function (Product) {
         var selectedOptions = [
-            {value: {min: 0, max:5}, label: '0 - 5', selected: false}, 
+            {value: {min: 0, max:5}, label: '0 - 5', selected: false},
         ];
         var product = new Product();
         product.reuses = 1;
@@ -94,6 +94,17 @@ describe('The product-grid component', function () {
 
         filtered = component.productNameSearchFilterFunc(product, 0, [product], '');
         expect(filtered).toBe(product);
+    }));
+
+    it('it can filter by product description', inject(function (Product) {
+        var product = new Product();
+        product.name = 'App Engine';
+        product.provider = 'Google';
+        product.csoDescription = 'Foo';
+
+        var filtered = component.productNameSearchFilterFunc(product, 0, [product], 'Foo');
+        expect(filtered).toBeDefined();
+        expect(filtered.csoDescription).toBe('Foo');
     }));
 
     it('it can filter by status', inject(function (Product) {


### PR DESCRIPTION
[Trello Card](https://trello.com/c/NFhL7JEu/27-include-other-data-fields-in-app-search-8)

Search functionality will now search through product `serviceDescription` field when user does a general text search