### PR TITLE
Minor items for 508 compliance

### DIFF
--- a/src/sass/filter-type.scss
+++ b/src/sass/filter-type.scss
@@ -37,6 +37,13 @@
     line-height: 8.5rem;
     margin-left: 0;
 
+    button h1,
+    button h2 {
+        margin: 0;
+        line-height: 1;
+        font-size: 1.8rem;
+    }
+
     .fr-filters-row {
         display: table-row;
 

--- a/src/templates/components/assessor.html
+++ b/src/templates/components/assessor.html
@@ -61,7 +61,7 @@
                 <dt ng-if="controller.model.pocEmail">E-mail:</dt>
                 <dd ng-if="controller.model.pocEmail"><a ng-href="mailto:{{controller.model.pocEmail}}" title="Email independent assessor">{{controller.model.pocEmail}}</a></dd>
                 <dt ng-if="controller.model.website">Website:</dt>
-                <dd ng-if="controller.model.website"><a ng-href="{{controller.externalLink(controller.model.website)}}" target="_blank" title="Visit independent assessor website">{{controller.model.website}}</a></dd>
+                <dd ng-if="controller.model.website"><a ng-href="{{controller.externalLink(controller.model.website)}}" target="_blank" title="Visit independent assessor website" class="usa-link usa-link--external">{{controller.model.website}}</a></dd>
                 <dt ng-if="controller.model.founded">Founded:</dt>
                 <dd ng-if="controller.model.founded">{{controller.model.founded}}</dd>
             </dl>

--- a/src/templates/components/menu.html
+++ b/src/templates/components/menu.html
@@ -5,21 +5,21 @@
                     type="radio"
                     ng-class="{'selected':controller.includes('**.product.**') || controller.includes('**.products')}"
                     ui-sref="fedramp.app.home.products"  title="Show Cloud Offerings (CSOs)">
-                <span>Products</span>
+                <h1><span style="display:none" aria-hidden="false">FedRAMP </span>Products</h1>
             </button>
         </div>
         <div class="usa-width-one-third">
             <button id="filterByAgency"
                     ng-class="{'selected':controller.includes('**.agency.**') || controller.includes('**.agencies')}"
                     ui-sref="fedramp.app.home.agencies" title="Show Government Agencies">
-                <span>Agencies</span>
+                <h2><span style="display:none" aria-hidden="false">FedRAMP </span>Agencies</h2>
             </button>
         </div>
         <div class="usa-width-one-third">
             <button id="filterBy3PAO"
                     ng-class="{'selected':controller.includes('**.assessor.**') || controller.includes('**.assessors')}"
                     ui-sref="fedramp.app.home.assessors" title="Show Assessment Organizations (3PAOs)">
-                <span>Assessors</span>
+                <h2><span style="display:none" aria-hidden="false">FedRAMP </span>Assessors</h2>
             </button>
         </div>
     </div>

--- a/src/templates/components/product.html
+++ b/src/templates/components/product.html
@@ -64,7 +64,7 @@
                 <dt ng-if="controller.model.pocEmail">E-mail:</dt>
                 <dd ng-if="controller.model.pocEmail"><a ng-href="mailto:{{controller.model.pocEmail}}" title="Email the provider">{{controller.model.pocEmail}}</a></dd>
                 <dt ng-if="controller.model.website">Website:</dt>
-                <dd ng-if="controller.model.website"><a ng-href="{{controller.externalLink(controller.model.website)}}" target="_blank" title="Visit the provider website">{{controller.model.website}}</a></dd>
+                <dd ng-if="controller.model.website"><a ng-href="{{controller.externalLink(controller.model.website)}}" target="_blank" title="Visit the provider website" class="usa-link usa-link--external">{{controller.model.website}}</a></dd>
             </dl>
         </div>
         <div class="col">

--- a/src/templates/components/tile-assessor.html
+++ b/src/templates/components/tile-assessor.html
@@ -15,7 +15,7 @@
                 <dt ng-if="controller.model.pocEmail">E-mail:</dt>
                 <dd ng-if="controller.model.pocEmail"><a ng-href="mailto:{{controller.model.pocEmail}}" title="Email independent assessor">{{controller.model.pocEmail}}</a></dd>
                 <dt ng-if="controller.model.website">Website:</dt>
-                <dd ng-if="controller.model.website"><a ng-href="{{controller.externalLink(controller.model.website)}}" target="_blank" title="Visit independent assessor website">{{controller.model.website}}</a></dd>
+                <dd ng-if="controller.model.website"><a ng-href="{{controller.externalLink(controller.model.website)}}" target="_blank" title="Visit independent assessor website" class="usa-link usa-link--external">{{controller.model.website}}</a></dd>
             </dl>
         </div>
         <div class="col reuses fr-grid-cell-metric">

--- a/src/templates/fedramp.html
+++ b/src/templates/fedramp.html
@@ -41,7 +41,7 @@
             <nav class="usa-footer__nav grid-row">
                 <ul class="usa-list usa-list--unstyled grid-col-4 usa-footer__primary-content">
                     <li class="usa-footer__primary-link">
-                        <h1>Contact Information</h1>
+                        <h3>Contact Information</h3>
                     </li>
                     <li>
                         <i class="fa fa-user" aria-hidden="true"></i>
@@ -61,7 +61,7 @@
                 </ul>
                 <ul class="usa-list usa-list--unstyled grid-col-4 usa-footer__primary-content">
                     <li class="usa-footer-primary-link">
-                        <h1>Follow @FedRAMP on Twitter</h1>
+                        <h3>Follow @FedRAMP on Twitter</h3>
                     </li>
                     <li>
                         <twitter>
@@ -71,7 +71,7 @@
                 </ul>
                 <ul class="usa-list usa-list--unstyled grid-col-4 usa-footer__primary-content">
                     <li class="usa-footer-primary-link">
-                        <h1>Subscribe to Updates</h1>
+                        <h3>Subscribe to Updates</h3>
                     </li>
                     <li><a href="https://public.govdelivery.com/accounts/USGSA/subscriber/topics?qsp=USGSA_2224">Add your email to FedRAMP's subscriber list.</a></li>
                 </ul>


### PR DESCRIPTION
- Add USWDS external link design to external hyperlinks
  - Any links off from govt websites now have the "external" icon next to them
- Remove h1 tags from footer, add h1 tags to above the fold (non-visible)
  - Product/Agency/Assessor tabs now represent the h1/h2's with non-visible text for screen readers. 

^ Both of these items are non-visible markup changes.



