### PR TITLE
Add Back to Top buttons at bottom of long lists

### DIFF
--- a/src/templates/components/agencies-grid.html
+++ b/src/templates/components/agencies-grid.html
@@ -33,6 +33,9 @@
         </div>
         <tile ng-repeat="item in controller.filteredData" model="item"></tile>
         <div class="empty-results" ng-if="controller.filteredData.length === 0">No results were found matching your filtering criteria</div>
+        <div class="padding-x-0 padding-y-1 hidden-print">
+            <button class='usa-button usa-button--unstyled' onClick="window.scrollTo({ top: 500, behavior: 'smooth' });">back to top</button>
+        </div>
     </div>
     <div class="clear"></div>
 </grid>

--- a/src/templates/components/assessors-grid.html
+++ b/src/templates/components/assessors-grid.html
@@ -33,6 +33,9 @@
         </div>
         <tile ng-repeat="item in controller.filteredData" model="item"></tile>
         <div class="empty-results" ng-if="controller.filteredData.length === 0">No results were found matching your filtering criteria</div>
+        <div class="padding-x-0 padding-y-1 hidden-print">
+            <button class='usa-button usa-button--unstyled' onClick="window.scrollTo({ top: 500, behavior: 'smooth' });">back to top</button>
+        </div>
     </div>
     <div class="clear"></div>
 </grid>

--- a/src/templates/components/products-grid.html
+++ b/src/templates/components/products-grid.html
@@ -43,6 +43,9 @@
         </div>
         <tile ng-repeat="item in controller.filteredData" model="item"></tile>
         <div class="empty-results" ng-if="controller.filteredData.length === 0">No results were found matching your filtering criteria</div>
+        <div class="padding-x-0 padding-y-1 hidden-print">
+            <button class='usa-button usa-button--unstyled' onClick="window.scrollTo({ top: 500, behavior: 'smooth' });">back to top</button>
+        </div>
     </div>
     <div class="clear"></div>
 </grid>


### PR DESCRIPTION
- Buttons are placed at the bottom of the content grids so that they left-align with the content.
- Buttons use JS to scroll to top since a reload of the page will always bring it back to the products tab.