### PR TITLE
Add FedRAMP Authorization date to auth status in products list

### DIFF
--- a/src/fedramp.components/product-status.component.js
+++ b/src/fedramp.components/product-status.component.js
@@ -8,6 +8,7 @@
             controller: ProductStatus,
             controllerAs: 'controller',
             bindings: {
+                model: '<',
                 status: '<'
             }
         });

--- a/src/templates/components/product-status.html
+++ b/src/templates/components/product-status.html
@@ -1,6 +1,6 @@
 <img ng-if="::controller.status === 'Compliant'" src="img/fedramp-process-compliant-blue.png" alt="Authorized" />
 <img ng-if="::controller.status === 'In Process'" src="img/fedramp-process-in-process-blue.png" alt="In-Process" />
 <img ng-if="::controller.status === 'FedRAMP Ready'" src="img/fedramp-process-ready-blue.png" alt="Ready" />
-<span ng-if="::controller.status === 'Compliant'">FedRAMP Authorized</span>
+<span ng-if="::controller.status === 'Compliant'">FedRAMP Authorized<br/>since {{ controller.model.compliantDate }}</span>
 <span ng-if="::controller.status === 'In Process'"> FedRAMP In Process</span>
 <span ng-if="::controller.status === 'FedRAMP Ready'">FedRAMP Ready</span>

--- a/src/templates/components/tile-product.html
+++ b/src/templates/components/tile-product.html
@@ -17,7 +17,7 @@
             <span>{{ ::controller.model.impactLevel }}</span>
         </div>
         <div class="col status fr-grid-cell-icon">
-            <product-status status="::controller.model.designation"></product-status>
+            <product-status status="::controller.model.designation" model="::controller.model"></product-status>
         </div>
         <div class="col reuses fr-grid-cell-metric">
             <div class="number">{{::controller.model.authorizations}}</div>


### PR DESCRIPTION
Users requested having this date up-front while browsing products.

<img width="255" alt="Screen Shot 2020-12-10 at 9 19 05 AM" src="https://user-images.githubusercontent.com/4267629/101792800-bd613000-3aca-11eb-8879-be87f7b99508.png">
