### PR TITLE
remove 'The' at beginning of names when sorting by name

### DIFF
--- a/src/fedramp.components/grid-sort.component.js
+++ b/src/fedramp.components/grid-sort.component.js
@@ -171,8 +171,8 @@
                 }
 
                 // Normalize everything and make it all lowercase for fair comparison
-                a = a.toLowerCase().replace(/^the/gi, '');
-                b = b.toLowerCase().replace(/^the/gi, '');
+                a = a.toLowerCase().replace(/^the\s+/gi, '');
+                b = b.toLowerCase().replace(/^the\s+/gi, '');
 
                 if (a < b) {
                     return self.asc ? -1 : 1;

--- a/src/fedramp.components/grid-sort.component.js
+++ b/src/fedramp.components/grid-sort.component.js
@@ -171,8 +171,8 @@
                 }
 
                 // Normalize everything and make it all lowercase for fair comparison
-                a = a.toLowerCase();
-                b = b.toLowerCase();
+                a = a.toLowerCase().replace(/^the/gi, '');
+                b = b.toLowerCase().replace(/^the/gi, '');
 
                 if (a < b) {
                     return self.asc ? -1 : 1;


### PR DESCRIPTION
Users expected names prefixed with 'The' to be sorted by their core name.

Examples: "The Coleridge Group", "The Arcanum Group"