### PR TITLE
Fix: remove sourcemap warnings / 404s from dev console

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -273,6 +273,7 @@ gulp.task('mangle:concat-libs', function () {
             'build/lib/uswds.min.js',
             'build/fedramp.min.js'
         ])
+        .pipe(replace(/\/\/# sourceMappingURL=.+.js.map/g, ''))
         .pipe(concat('fedramp.min.js'))
         .pipe(gulp.dest('build/'));
 });
@@ -334,7 +335,6 @@ gulp.task("build-sass", function(done) {
             'node_modules/font-awesome/**/*.scss',
             `${PROJECT_SASS_SRC}/index.scss`
         ])
-      .pipe(sourcemaps.init({ largeFile: true }))
       .pipe(
         sass.sync({
           includePaths: [
@@ -346,7 +346,6 @@ gulp.task("build-sass", function(done) {
       )
       .pipe(replace(/\buswds @version\b/g, "based on uswds v" + pkg.version))
       .pipe(postcss(plugins))
-      .pipe(sourcemaps.write("."))
       // uncomment the next line if necessary for Jekyll to build properly
       //.pipe(gulp.dest(`${SITE_CSS_DEST}`))
       .pipe(concat('fedramp.css'))


### PR DESCRIPTION
The app bundle was throwing some warnings about missing sourcemap files on page load.

This is because the Gulp build task collects and concatenates minified js files from vendors into the main build. Each of these files has its own sourcemapping, but the gulp build doesn't transfer them along with the js.

A long-term solution would be to somehow include the vendor sourcemap files in the build. This may take some time to fix, and could greatly increase the build size.

For now, removing the links from each minified js file removes the console warnings.