### PR TITLE
Improve logo load performance

### DIFF
--- a/src/fedramp.services/storage-data.factory.js
+++ b/src/fedramp.services/storage-data.factory.js
@@ -144,7 +144,7 @@
                     item.deploymentModel = d.deploymentModel.trim();
                     item.designation = d.designation.trim();
                     item.impactLevel = d.impactLevel.trim();
-                    item.logo = d.cspUrl;
+                    item.logo = d.cspUrl.replace('https://marketplace.fedramp.gov/', '');
                     item.independentAssessor = d.independentAssessor;
                     item.authorizationType = d.path;
                     item.sponsoringAgency = d.sponsoringAgency;


### PR DESCRIPTION
Using the full url for images causes up to a minute of load time for table data and prevents other page assets from loading until images are finished.

Since the images are stored locally in /dist, we can just link to those.

Commit removes the http domain from the img links (derived from CSP_URL in data)